### PR TITLE
Adding special type for Paginator and FixedLengthPaginator classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor
 /build
+/.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
 
     <php>
         <env name="APP_KEY" value="9E6B382F19C53C5327840752500B0260"/>
+        <env name="APP_DEBUG" value="true"/>
     </php>
 
     <filter>

--- a/src/Mappers/PaginatorMissingParameterException.php
+++ b/src/Mappers/PaginatorMissingParameterException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Laravel\Mappers;
+
+use Exception;
+use GraphQL\Error\ClientAware;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeTrait;
+
+class PaginatorMissingParameterException extends Exception implements ClientAware, CannotMapTypeExceptionInterface
+{
+    use CannotMapTypeTrait;
+
+    public static function missingLimit(): self
+    {
+        return new self('In the items field of a paginator, you cannot add a "offset" without also adding a "limit"');
+    }
+
+    public static function noSubType(): self
+    {
+        return new self('Result sets implementing Laravel Paginator need to have a subtype. Please define it using @return annotation. For instance: "@return User[]"');
+    }
+
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     */
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     */
+    public function getCategory(): string
+    {
+        return 'pagination';
+    }
+}

--- a/src/Mappers/PaginatorTypeMapper.php
+++ b/src/Mappers/PaginatorTypeMapper.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Laravel\Mappers;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NullableType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
+use Porpaginas\Result;
+use RuntimeException;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\PorpaginasMissingParameterException;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use function get_class;
+use function is_a;
+use function strpos;
+use function substr;
+
+class PaginatorTypeMapper implements TypeMapperInterface
+{
+    /** @var array<string, MutableInterface&(MutableObjectType|MutableInterfaceType)> */
+    private $cache = [];
+    /** @var RecursiveTypeMapperInterface */
+    private $recursiveTypeMapper;
+
+    public function __construct(RecursiveTypeMapperInterface $recursiveTypeMapper)
+    {
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+    }
+
+    /**
+     * Returns true if this type mapper can map the $className FQCN to a GraphQL type.
+     *
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     */
+    public function canMapClassToType(string $className): bool
+    {
+        return is_a($className, Paginator::class, true);
+    }
+
+    /**
+     * Maps a PHP fully qualified class name to a GraphQL type.
+     *
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
+     *
+     * @return MutableObjectType|MutableInterfaceType
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
+    {
+        if (! $this->canMapClassToType($className)) {
+            throw CannotMapTypeException::createForType($className);
+        }
+        if ($subType === null) {
+            throw PaginatorMissingParameterException::noSubType();
+        }
+
+        return $this->getObjectType(is_a($className, LengthAwarePaginator::class, true), $subType);
+    }
+
+    /**
+     * @param OutputType&Type $subType
+     *
+     * @return MutableObjectType|MutableInterfaceType
+     */
+    private function getObjectType(bool $countable, OutputType $subType): MutableInterface
+    {
+        if (! isset($subType->name)) {
+            throw new RuntimeException('Cannot get name property from sub type ' . get_class($subType));
+        }
+
+        $name = $subType->name;
+
+        $typeName = 'PaginatorResult_' . $name;
+
+        if ($subType instanceof NullableType) {
+            $subType = Type::nonNull($subType);
+        }
+
+        if (! isset($this->cache[$typeName])) {
+            $this->cache[$typeName] = new MutableObjectType([
+                'name' => $typeName,
+                'fields' => static function () use ($subType, $countable) {
+                    $fields = [
+                        'items' => [
+                            'type' => Type::nonNull(Type::listOf($subType)),
+                            'resolve' => static function (Paginator $root) {
+                                return $root->items();
+                            },
+                        ],
+                        'firstItem' => [
+                            'type' => Type::int(),
+                            'description' => 'Get the "index" of the first item being paginated.',
+                            'resolve' => static function (Paginator $root): int {
+                                return $root->firstItem();
+                            },
+                        ],
+                        'lastItem' => [
+                            'type' => Type::int(),
+                            'description' => 'Get the "index" of the last item being paginated.',
+                            'resolve' => static function (Paginator $root): int {
+                                return $root->lastItem();
+                            },
+                        ],
+                        'hasMorePages' => [
+                            'type' => Type::boolean(),
+                            'description' => 'Determine if there are more items in the data source.',
+                            'resolve' => static function (Paginator $root): bool {
+                                return $root->hasMorePages();
+                            },
+                        ],
+                        'perPage' => [
+                            'type' => Type::int(),
+                            'description' => 'Get the number of items shown per page.',
+                            'resolve' => static function (Paginator $root): int {
+                                return $root->perPage();
+                            },
+                        ],
+                        'hasPages' => [
+                            'type' => Type::boolean(),
+                            'description' => 'Determine if there are enough items to split into multiple pages.',
+                            'resolve' => static function (Paginator $root): bool {
+                                return $root->hasPages();
+                            },
+                        ],
+                        'currentPage' => [
+                            'type' => Type::int(),
+                            'description' => 'Determine the current page being paginated.',
+                            'resolve' => static function (Paginator $root): int {
+                                return $root->currentPage();
+                            },
+                        ],
+                        'isEmpty' => [
+                            'type' => Type::boolean(),
+                            'description' => 'Determine if the list of items is empty or not.',
+                            'resolve' => static function (Paginator $root): bool {
+                                return $root->isEmpty();
+                            },
+                        ],
+                        'isNotEmpty' => [
+                            'type' => Type::boolean(),
+                            'description' => 'Determine if the list of items is not empty.',
+                            'resolve' => static function (Paginator $root): bool {
+                                return $root->isNotEmpty();
+                            },
+                        ],
+                    ];
+
+                    if ($countable) {
+                        $fields['totalCount'] = [
+                            'type' => Type::int(),
+                            'description' => 'The total count of items.',
+                            'resolve' => static function (LengthAwarePaginator $root): int {
+                                return $root->total();
+                            }];
+                        $fields['lastPage'] = [
+                            'type' => Type::int(),
+                            'description' => 'Get the page number of the last available page.',
+                            'resolve' => static function (LengthAwarePaginator $root): int {
+                                return $root->lastPage();
+                            }];
+                    }
+
+                    return $fields;
+                },
+            ]);
+        }
+
+        return $this->cache[$typeName];
+    }
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     */
+    public function canMapNameToType(string $typeName): bool
+    {
+        return strpos($typeName, 'PaginatorResult_') === 0 || strpos($typeName, 'LengthAwarePaginatorResult_') === 0;
+    }
+
+    /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     *
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function mapNameToType(string $typeName): Type
+    {
+        if (strpos($typeName, 'LengthAwarePaginatorResult_') === 0) {
+            $subTypeName = substr($typeName, 27);
+            $lengthAware = true;
+        } elseif (strpos($typeName, 'PaginatorResult_') === 0) {
+            $subTypeName = substr($typeName, 16);
+            $lengthAware = false;
+        } else {
+            throw CannotMapTypeException::createForName($typeName);
+        }
+
+        $subType = $this->recursiveTypeMapper->mapNameToType($subTypeName);
+
+        if (! $subType instanceof OutputType) {
+            throw CannotMapTypeException::mustBeOutputType($subTypeName);
+        }
+
+        return $this->getObjectType($lengthAware, $subType);
+    }
+
+    /**
+     * Returns the list of classes that have matching input GraphQL types.
+     *
+     * @return string[]
+     */
+    public function getSupportedClasses(): array
+    {
+        // We cannot get the list of all possible porpaginas results but this is not an issue.
+        // getSupportedClasses is only useful to get classes that can be hidden behind interfaces
+        // and Porpaginas results are not part of those.
+        return [];
+    }
+
+    /**
+     * Returns true if this type mapper can map the $className FQCN to a GraphQL input type.
+     */
+    public function canMapClassToInputType(string $className): bool
+    {
+        return false;
+    }
+
+    /**
+     * Maps a PHP fully qualified class name to a GraphQL input type.
+     *
+     * @return ResolvableMutableInputInterface&InputObjectType
+     */
+    public function mapClassToInputType(string $className): ResolvableMutableInputInterface
+    {
+        throw CannotMapTypeException::createForInputType($className);
+    }
+
+    /**
+     * Returns true if this type mapper can extend an existing type for the $className FQCN
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     */
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
+    {
+        return false;
+    }
+
+    /**
+     * Extends the existing GraphQL type that is mapped to $className.
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function extendTypeForClass(string $className, MutableInterface $type): void
+    {
+        throw CannotMapTypeException::createForExtendType($className, $type);
+    }
+
+    /**
+     * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     */
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
+    {
+        return false;
+    }
+
+    /**
+     * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
+    {
+        throw CannotMapTypeException::createForExtendName($typeName, $type);
+    }
+
+    /**
+     * Returns true if this type mapper can decorate an existing input type for the $typeName GraphQL input type
+     */
+    public function canDecorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): bool
+    {
+        return false;
+    }
+
+    /**
+     * Decorates the existing GraphQL input type that is mapped to the $typeName GraphQL input type.
+     *
+     * @param ResolvableMutableInputInterface&InputObjectType $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function decorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): void
+    {
+        throw CannotMapTypeException::createForDecorateName($typeName, $type);
+    }
+}

--- a/src/Mappers/PaginatorTypeMapperFactory.php
+++ b/src/Mappers/PaginatorTypeMapperFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Laravel\Mappers;
+
+
+use TheCodingMachine\GraphQLite\FactoryContext;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperFactoryInterface;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
+
+class PaginatorTypeMapperFactory implements TypeMapperFactoryInterface
+{
+
+    public function create(FactoryContext $context): TypeMapperInterface
+    {
+        return new PaginatorTypeMapper($context->getRecursiveTypeMapper());
+    }
+}

--- a/src/Providers/GraphQLiteServiceProvider.php
+++ b/src/Providers/GraphQLiteServiceProvider.php
@@ -4,6 +4,8 @@ namespace TheCodingMachine\GraphQLite\Laravel\Providers;
 
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use TheCodingMachine\GraphQLite\Laravel\Mappers\PaginatorTypeMapper;
+use TheCodingMachine\GraphQLite\Laravel\Mappers\PaginatorTypeMapperFactory;
 use TheCodingMachine\GraphQLite\Laravel\Security\AuthenticationService;
 use TheCodingMachine\GraphQLite\Laravel\Security\AuthorizationService;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
@@ -91,6 +93,7 @@ class GraphQLiteServiceProvider extends ServiceProvider
             $service = new SchemaFactory($app->make('graphqliteCache'), new SanePsr11ContainerAdapter($app));
             $service->setAuthenticationService($app[AuthenticationService::class]);
             $service->setAuthorizationService($app[AuthorizationService::class]);
+            $service->addTypeMapperFactory($app[PaginatorTypeMapperFactory::class]);
 
             $controllers = config('graphqlite.controllers', 'App\\Http\\Controllers');
             if (!is_iterable($controllers)) {

--- a/tests/Fixtures/App/Http/Controllers/TestController.php
+++ b/tests/Fixtures/App/Http/Controllers/TestController.php
@@ -4,6 +4,7 @@
 namespace App\Http\Controllers;
 
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 
@@ -24,5 +25,14 @@ class TestController
     public function testLogged(): string
     {
         return 'foo';
+    }
+
+    /**
+     * @Query()
+     * @return int[]
+     */
+    public function testPaginator(): LengthAwarePaginator
+    {
+        return new LengthAwarePaginator([1,2,3,4], 42, 4, 2);
     }
 }

--- a/tests/Providers/GraphQLiteServiceProviderTest.php
+++ b/tests/Providers/GraphQLiteServiceProviderTest.php
@@ -33,4 +33,49 @@ class GraphQLiteServiceProviderTest extends TestCase
         $this->assertSame(200, $response->getStatusCode(), $response->getContent());
         $response->assertJson(["errors" => [["message" => "You need to be logged to access this field"]]]);
     }
+
+    public function testPagination()
+    {
+        $response = $this->json('POST', '/graphql', ['query' => <<<GQL
+{ 
+    testPaginator {
+        items
+        firstItem
+        lastItem
+        hasMorePages
+        perPage
+        hasPages
+        currentPage
+        isEmpty
+        isNotEmpty
+        totalCount
+        lastPage
+    }
+}
+GQL
+]);
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+        $response->assertJson([
+    "data" => [
+        "testPaginator" => [
+            "items" => [
+                1,
+                2,
+                3,
+                4
+            ],
+            "firstItem" => 5,
+            "lastItem" => 8,
+            "hasMorePages" => true,
+            "perPage" => 4,
+            "hasPages" => true,
+            "currentPage" => 2,
+            "isEmpty" => false,
+            "isNotEmpty" => true,
+            "totalCount" => 42,
+            "lastPage" => 11,
+        ]
+    ]
+]);
+    }
 }


### PR DESCRIPTION
## Support for pagination

In your query, if you explicitly return an object that extends the `Illuminate\Pagination\LengthAwarePaginator` class,
the query result will be wrapped in a "paginator" type.

```php
class MyController
{
    /**
     * @Query
     * @return Product[]
     */
    public function products(): Illuminate\Pagination\LengthAwarePaginator
    {
        return Product::paginate(15);
    }
}
```

Notice that:

- the method return type MUST BE `Illuminate\Pagination\LengthAwarePaginator` or a class extending `Illuminate\Pagination\LengthAwarePaginator`
- you MUST add a `@return` statement to help GraphQLite find the type of the list

Once this is done, you can get plenty of useful information about this page:

```
products {
    items {      # The items for the selected page
        id
        name
    }
    totalCount   # The total count of items.
    lastPage     # Get the page number of the last available page.
    firstItem    # Get the "index" of the first item being paginated.
    lastItem     # Get the "index" of the last item being paginated.
    hasMorePages # Determine if there are more items in the data source.
    perPage      # Get the number of items shown per page.
    hasPages     # Determine if there are enough items to split into multiple pages.
    currentPage  # Determine the current page being paginated.
    isEmpty      # Determine if the list of items is empty or not.
    isNotEmpty   # Determine if the list of items is not empty.
}
```


<div class="alert alert-warning">Be sure to type hint on the class (<code>Illuminate\Pagination\LengthAwarePaginator</code>)
and not on the interface (<code>Illuminate\Contracts\Pagination\LengthAwarePaginator</code>). The interface
itself is not iterable (it does not extend <code>Traversable</code>) and therefore, GraphQLite will refuse to
iterate over it.</div>

### Simple paginator

Note: if you are using `simplePaginate` instead of `paginate`, you can type hint on the `Illuminate\Pagination\Paginator` class.

```php
class MyController
{
    /**
     * @Query
     * @return Product[]
     */
    public function products(): Illuminate\Pagination\Paginator
    {
        return Product::simplePaginate(15);
    }
}
```

The behaviour will be exactly the same except you will be missing the `totalCount` and `lastPage` fields.
