### PR TITLE
Making sure the GraphQLite cache is purged when the cache:clear command is called.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/src/Listeners/CachePurger.php
+++ b/src/Listeners/CachePurger.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Laravel\Listeners;
+
+
+use Psr\SimpleCache\CacheInterface;
+
+class CachePurger
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->cache->clear();
+    }
+}

--- a/tests/Providers/GraphQLiteServiceProviderTest.php
+++ b/tests/Providers/GraphQLiteServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQLite\Laravel\Providers;
 
 
 use Orchestra\Testbench\TestCase;
+use TheCodingMachine\GraphQLite\Laravel\Listeners\CachePurger;
 use TheCodingMachine\GraphQLite\Schema;
 use TheCodingMachine\TDBM\TDBMService;
 use function json_decode;
@@ -162,5 +163,11 @@ GQL
 
         $response = $this->json('POST', '/graphql', ['query' => '{ testValidatorMultiple(foo:"192.168.1.1") }']);
         $this->assertSame(200, $response->getStatusCode(), $response->getContent());
+    }
+
+    public function testCachePurger(): void
+    {
+        $cachePurger = $this->app->make(CachePurger::class);
+        $cachePurger->handle();
     }
 }

--- a/tests/Providers/GraphQLiteServiceProviderTest.php
+++ b/tests/Providers/GraphQLiteServiceProviderTest.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\GraphQLite\Laravel\Providers;
 use Orchestra\Testbench\TestCase;
 use TheCodingMachine\GraphQLite\Schema;
 use TheCodingMachine\TDBM\TDBMService;
+use function json_decode;
 
 class GraphQLiteServiceProviderTest extends TestCase
 {
@@ -110,7 +111,6 @@ GQL
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'The foo must start with one of the following: 192',
                     'extensions' => [
                         'argument' => 'foo',
                         'category' => 'Validate'
@@ -125,6 +125,8 @@ GQL
                 ]
             ]
         ]);
+
+        $this->assertContains('The foo must start with one of the following: 192', $response->json('errors')[0]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
         $response = $this->json('POST', '/graphql', ['query' => '{ testValidatorMultiple(foo:"192.168.1") }']);
@@ -147,7 +149,6 @@ GQL
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'The foo must start with one of the following: 192',
                     'extensions' => [
                         'argument' => 'foo',
                         'category' => 'Validate'
@@ -155,6 +156,7 @@ GQL
                 ]
             ]
         ]);
+        $this->assertContains('The foo must start with one of the following: 192', $response->json('errors')[0]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
 


### PR DESCRIPTION
Closes #17 

TODO:

- [x] Test this
- [ ] Make sur APCu cache is purged from command line (try to understand how this works in Laravel from Laravel APC cache)