### PR TITLE
Add a config variable to set the HTTP code in the operations

### DIFF
--- a/config/graphqlite.php
+++ b/config/graphqlite.php
@@ -1,6 +1,7 @@
 <?php
 
 use GraphQL\Error\Debug;
+use TheCodingMachine\GraphQLite\Http\HttpCodeDecider;
 
 return [
     /*
@@ -21,4 +22,7 @@ return [
     'debug' => Debug::RETHROW_UNSAFE_EXCEPTIONS,
     'uri' => env('GRAPHQLITE_URI', '/graphql'),
     'middleware' =>  ['web'],
+
+    // Sets the status code in the HTTP request where operations have errors.
+    'decider' => HttpCodeDecider::class,
 ];

--- a/src/Providers/GraphQLiteServiceProvider.php
+++ b/src/Providers/GraphQLiteServiceProvider.php
@@ -19,6 +19,7 @@ use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\Context\Context;
 use TheCodingMachine\GraphQLite\Exceptions\WebonyxErrorHandler;
+use TheCodingMachine\GraphQLite\Http\HttpCodeDecider;
 use TheCodingMachine\GraphQLite\Laravel\Listeners\CachePurger;
 use TheCodingMachine\GraphQLite\Laravel\Mappers\Parameters\ValidateFieldMiddleware;
 use TheCodingMachine\GraphQLite\Laravel\Mappers\PaginatorTypeMapper;
@@ -88,8 +89,14 @@ class GraphQLiteServiceProvider extends ServiceProvider
 
         $this->app->singleton(GraphQLiteController::class, function (Application $app) {
             $debug = config('graphqlite.debug', DebugFlag::RETHROW_UNSAFE_EXCEPTIONS);
+            $controller = new GraphQLiteController($app[StandardServer::class], $app[HttpMessageFactoryInterface::class], $debug);
+            $decider = config('graphqlite.decider');
 
-            return new GraphQLiteController($app[StandardServer::class], $app[HttpMessageFactoryInterface::class], $debug);
+            if (!empty($decider)) {
+                $controller->setCodeDecider($app[$decider]);
+            }
+
+            return $controller;
         });
 
         $this->app->singleton(StandardServer::class, static function (Application $app) {


### PR DESCRIPTION
In the default implementation in GraphQLite when an operation result
has any error the status code by default is Bad Request (400), this is
not the way how GraphQL clients expects a response, with this setter we
can set a custom behavior to handle this cases.