### PR TITLE
fix: `debug` setting in graphqlite config file

### DIFF
--- a/config/graphqlite.php
+++ b/config/graphqlite.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Error\Debug;
+use GraphQL\Error\DebugFlag;
 
 return [
     /*
@@ -18,7 +18,7 @@ return [
      */
     'controllers' => 'App\\Http\\Controllers',
     'types' => 'App\\',
-    'debug' => Debug::RETHROW_UNSAFE_EXCEPTIONS,
+    'debug' => DebugFlag::RETHROW_UNSAFE_EXCEPTIONS,
     'uri' => env('GRAPHQLITE_URI', '/graphql'),
     'middleware' =>  ['web'],
 ];


### PR DESCRIPTION
Hey there,

`GraphQL\Error\Debug` was renamed to `GraphQL\Error\DebugFlag` in WebonyxGraphQL version 14.