### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "test": "phpunit"
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2|^8",
         "thecodingmachine/graphqlite": "^5.0",
-        "illuminate/console": "^5.7|^6.0|^7|^8",
-        "illuminate/container": "^5.7|^6.0|^7|^8",
-        "illuminate/support": "^5.7|^6.0|^7|^8",
-        "illuminate/cache": "^5.7|^6.0|^7|^8",
+        "illuminate/console": "^5.7|^6.0|^7|^8|^9",
+        "illuminate/container": "^5.7|^6.0|^7|^8|^9",
+        "illuminate/support": "^5.7|^6.0|^7|^8|^9",
+        "illuminate/cache": "^5.7|^6.0|^7|^8|^9",
         "symfony/psr-http-message-bridge": "^1.3.0 || ^2",
         "laminas/laminas-diactoros": "^2.2.2",
         "symfony/cache": "^4.3 || ^5"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/cache": "^5.7|^6.0|^7|^8|^9",
         "symfony/psr-http-message-bridge": "^1.3.0 || ^2",
         "laminas/laminas-diactoros": "^2.2.2",
-        "symfony/cache": "^4.3 || ^5"
+        "symfony/cache": "^4.3 || ^5 || ^6"
     },
     "require-dev": {
         "orchestra/testbench": "^3.7.7 || ^4 || ^5",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=7.2|^8",
-        "thecodingmachine/graphqlite": "^5.0",
+        "thecodingmachine/graphqlite": "^6.0",
         "illuminate/console": "^5.7|^6.0|^7|^8|^9",
         "illuminate/container": "^5.7|^6.0|^7|^8|^9",
         "illuminate/support": "^5.7|^6.0|^7|^8|^9",


### PR DESCRIPTION
This PR adds support for Laravel 9 and PHP 8+.
symfony/cache had to be bumped to 6 because 6 is forced on Laravel 9.