### PR TITLE
Adding compatibility with Laravel 9 and 10

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         install-args: ['', '--prefer-lowest']
-        php-version: ['7.4', '8.0']
+        php-version: ['8.1', '8.2']
       fail-fast: false
 
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,8 +15,13 @@ jobs:
 
     strategy:
       matrix:
-        install-args: ['', '--prefer-lowest']
-        php-version: ['8.1', '8.2']
+        include:
+          - install-args: "--prefer-lowest"
+            php-version: "8.1"
+          - install-args: ""
+            php-version: "8.1"
+          - install-args: ""
+            php-version: "8.2"
       fail-fast: false
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,20 @@
         "test": "phpunit"
     },
     "require": {
-        "php": ">=7.2|^8",
-        "thecodingmachine/graphqlite": "^6.0",
-        "illuminate/console": "^5.7|^6.0|^7|^8|^9",
-        "illuminate/container": "^5.7|^6.0|^7|^8|^9",
-        "illuminate/support": "^5.7|^6.0|^7|^8|^9",
-        "illuminate/cache": "^5.7|^6.0|^7|^8|^9",
+        "php": "^8.1",
+        "thecodingmachine/graphqlite": "^v6.2.1",
+        "illuminate/console": "^9 || ^10",
+        "illuminate/container": "^9 || ^10",
+        "illuminate/support": "^9 || ^10",
+        "illuminate/cache": "^9 || ^10",
         "symfony/psr-http-message-bridge": "^1.3.0 || ^2",
         "laminas/laminas-diactoros": "^2.2.2",
-        "symfony/cache": "^4.3 || ^5 || ^6"
+        "symfony/cache": "^4.3 || ^5 || ^6",
+        "psr/container": "^2.0.2"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7.7 || ^4 || ^5",
-        "phpunit/phpunit": "^7.5.4 || ^8.3",
+        "orchestra/testbench": "^7 || ^8",
+        "phpunit/phpunit": "^9.6.6 || ^10.0.19",
         "ext-sqlite3": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {
             "name": "David N\u00e9grier",
             "email": "d.negrier@thecodingmachine.com",
-            "homepage": "http://mouf-php.com"
+            "homepage": "https://workadventu.re"
         }
     ],
     "scripts": {
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.0.x-dev"
+            "dev-master": "6.1.x-dev"
         },
         "laravel": {
             "providers": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <php>
-        <env name="APP_KEY" value="9E6B382F19C53C5327840752500B0260"/>
-        <env name="APP_DEBUG" value="true"/>
-    </php>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">src/routes</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="build/coverage" />
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">src/routes</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_KEY" value="9E6B382F19C53C5327840752500B0260"/>
+    <env name="APP_DEBUG" value="true"/>
+  </php>
+  <logging/>
 </phpunit>

--- a/src/Exceptions/ValidateException.php
+++ b/src/Exceptions/ValidateException.php
@@ -19,20 +19,9 @@ class ValidateException extends \Exception implements GraphQLExceptionInterface
         return $exception;
     }
 
-    /**
-     * @return bool
-     */
-    public function isClientSafe()
+    public function isClientSafe(): bool
     {
         return true;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCategory()
-    {
-        return 'Validate';
     }
 
 

--- a/src/Mappers/PaginatorTypeMapper.php
+++ b/src/Mappers/PaginatorTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Laravel\Mappers;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
@@ -196,11 +197,11 @@ class PaginatorTypeMapper implements TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
+     * @return Type&NamedType&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
      *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapNameToType(string $typeName): Type
+    public function mapNameToType(string $typeName): Type&NamedType
     {
         if (strpos($typeName, 'LengthAwarePaginatorResult_') === 0) {
             $subTypeName = substr($typeName, 27);

--- a/src/Mappers/Parameters/ParameterValidator.php
+++ b/src/Mappers/Parameters/ParameterValidator.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\GraphQLite\Laravel\Mappers\Parameters;
 
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Validation\Factory as ValidationFactory;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
 use TheCodingMachine\GraphQLite\Laravel\Exceptions\ValidateException;
@@ -45,11 +46,8 @@ class ParameterValidator implements InputTypeParameterInterface
 
     /**
      * @param array<string, mixed> $args
-     * @param mixed $context
-     *
-     * @return mixed
      */
-    public function resolve(?object $source, array $args, $context, ResolveInfo $info)
+    public function resolve(?object $source, array $args, mixed $context, ResolveInfo $info): mixed
     {
         $value = $this->parameter->resolve($source, $args, $context, $info);
 
@@ -68,7 +66,7 @@ class ParameterValidator implements InputTypeParameterInterface
         return $value;
     }
 
-    public function getType(): InputType
+    public function getType(): InputType&Type
     {
         return $this->parameter->getType();
     }
@@ -78,10 +76,7 @@ class ParameterValidator implements InputTypeParameterInterface
         return $this->parameter->hasDefaultValue();
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDefaultValue()
+    public function getDefaultValue(): mixed
     {
         return $this->parameter->getDefaultValue();
     }

--- a/src/SanePsr11ContainerAdapter.php
+++ b/src/SanePsr11ContainerAdapter.php
@@ -53,7 +53,7 @@ class SanePsr11ContainerAdapter implements ContainerInterface
      *
      * @return bool
      */
-    public function has($id)
+    public function has($id): bool
     {
         if (class_exists($id) && !$this->container->has($id)) {
             try {

--- a/tests/Providers/GraphQLiteServiceProviderTest.php
+++ b/tests/Providers/GraphQLiteServiceProviderTest.php
@@ -87,21 +87,19 @@ GQL
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'The foo must be a valid email address.',
                     'extensions' => [
                         'argument' => 'foo',
-                        'category' => 'Validate'
                     ],
                 ],
                 [
-                    'message' => 'The bar must be greater than 42.',
                     'extensions' => [
                         'argument' => 'bar',
-                        'category' => 'Validate'
                     ],
                 ]
             ]
         ]);
+        $this->assertStringContainsString('must be a valid email address.', $response->json('errors')[0]['message']);
+        $this->assertStringContainsString('must be greater than 42.', $response->json('errors')[1]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
     }
@@ -114,34 +112,31 @@ GQL
                 [
                     'extensions' => [
                         'argument' => 'foo',
-                        'category' => 'Validate'
                     ],
                 ],
                 [
-                    'message' => 'The foo must be a valid IPv4 address.',
                     'extensions' => [
                         'argument' => 'foo',
-                        'category' => 'Validate'
                     ],
                 ]
             ]
         ]);
 
-        $this->assertStringContainsString('The foo must start with one of the following: 192', $response->json('errors')[0]['message']);
+        $this->assertStringContainsString('must start with one of the following: 192', $response->json('errors')[0]['message']);
+        $this->assertStringContainsString('must be a valid IPv4 address.', $response->json('errors')[1]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
         $response = $this->json('POST', '/graphql', ['query' => '{ testValidatorMultiple(foo:"192.168.1") }']);
         $response->assertJson([
             'errors' => [
                 [
-                    'message' => 'The foo must be a valid IPv4 address.',
                     'extensions' => [
                         'argument' => 'foo',
-                        'category' => 'Validate'
                     ],
                 ]
             ]
         ]);
+        $this->assertStringContainsString('must be a valid IPv4 address.', $response->json('errors')[0]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
 
@@ -152,12 +147,11 @@ GQL
                 [
                     'extensions' => [
                         'argument' => 'foo',
-                        'category' => 'Validate'
                     ],
                 ]
             ]
         ]);
-        $this->assertStringContainsString('The foo must start with one of the following: 192', $response->json('errors')[0]['message']);
+        $this->assertStringContainsString('must start with one of the following: 192', $response->json('errors')[0]['message']);
 
         $this->assertSame(400, $response->getStatusCode(), $response->getContent());
 


### PR DESCRIPTION
Laravel 9 and 10 require jumping PHP version.
Because thecodingmachine/graphqlite 6.2 uses the newer psr/container (also used by this package) it requires upgrading a number of classes.

Therefore, this commit needs to be tagged as a new minor release at least.