### PR TITLE
Adding a graphqlite:export-schema command

### DIFF
--- a/src/Console/Commands/GraphqliteExportSchema.php
+++ b/src/Console/Commands/GraphqliteExportSchema.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Laravel\Console\Commands;
+
+use GraphQL\Utils\SchemaPrinter;
+use Illuminate\Console\Command;
+use TheCodingMachine\GraphQLite\Schema;
+
+/**
+ * A command to export the GraphQL schema in "Schema Definition Language" (SDL) format.
+ */
+class GraphqliteExportSchema extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'graphqlite:export-schema {--O|output= : Output file name. If not specified, prints on stdout}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Exports the GraphQL schema in "Schema Definition Language" (SDL) format.';
+
+    public function __construct(private Schema $schema)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $output = $this->option('output');
+
+        $sdl = SchemaPrinter::doPrint($this->schema, [
+            "sortArguments" => true,
+            "sortEnumValues" => true,
+            "sortFields" => true,
+            "sortInputFields" => true,
+            "sortTypes" => true,
+        ]);
+
+        if ($output === null) {
+            $this->line($sdl);
+        } else {
+            file_put_contents($output, $sdl);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Console/Commands/GraphqliteExportSchemaTest.php
+++ b/tests/Console/Commands/GraphqliteExportSchemaTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Laravel\Console\Commands;
+
+
+use Orchestra\Testbench\TestCase;
+use TheCodingMachine\GraphQLite\Laravel\Providers\GraphQLiteServiceProvider;
+use TheCodingMachine\TDBM\TDBMService;
+
+
+class GraphqliteExportSchemaTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [GraphQLiteServiceProvider::class];
+    }
+
+    public function testCommand(): void
+    {
+        $this->artisan('graphqlite:export-schema -O test.graphql')
+            ->assertExitCode(0);
+
+        $this->assertFileExists('test.graphql');
+        $content = file_get_contents('test.graphql');
+        $this->assertStringContainsString('type Query {', $content);
+        unlink('test.graphql');
+    }
+}


### PR DESCRIPTION
This new Laravel command can be run using

```
./artisan graphqlite:export-schema --output file.schema
```

It will output the content of the Schema to an SDL file. This can be useful for instance for tools like graphql-codegen.