### PR TITLE
Overriding SchemaPrinter to bypass check on Subscriptions.

### DIFF
--- a/src/Console/Commands/GraphqliteExportSchema.php
+++ b/src/Console/Commands/GraphqliteExportSchema.php
@@ -2,8 +2,8 @@
 
 namespace TheCodingMachine\GraphQLite\Laravel\Console\Commands;
 
-use GraphQL\Utils\SchemaPrinter;
 use Illuminate\Console\Command;
+use TheCodingMachine\GraphQLite\Laravel\Utils\SchemaPrinter;
 use TheCodingMachine\GraphQLite\Schema;
 
 /**

--- a/src/Providers/GraphQLiteServiceProvider.php
+++ b/src/Providers/GraphQLiteServiceProvider.php
@@ -153,14 +153,6 @@ class GraphQLiteServiceProvider extends ServiceProvider
 
             $service->addTypeMapperFactory($app[PaginatorTypeMapperFactory::class]);
 
-            // We need to configure an empty Subscription type to avoid an exception in the generate-schema command.
-            $config = SchemaConfig::create();
-            $config->setSubscription(new ObjectType([
-                'name' => 'Subscription',
-                'fields' => [],
-            ]));
-            $service->setSchemaConfig($config);
-
             $controllers = config('graphqlite.controllers', 'App\\Http\\Controllers');
             if (!is_iterable($controllers)) {
                 $controllers = [ $controllers ];

--- a/src/Utils/SchemaPrinter.php
+++ b/src/Utils/SchemaPrinter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Laravel\Utils;
+
+use GraphQL\Type\Schema;
+
+class SchemaPrinter extends \GraphQL\Utils\SchemaPrinter
+{
+    /**
+     * In GraphQLite, getType throws an exception if not found. The "Subscription" type is never present.
+     * So it throws always. We reimplement this method to avoid throwing.
+     */
+    protected static function hasDefaultRootOperationTypes(Schema $schema): bool
+    {
+        return $schema->getQueryType() && $schema->getQueryType() === $schema->getType('Query')
+            && $schema->getMutationType() && $schema->getMutationType() === $schema->getType('Mutation');
+    }
+}


### PR DESCRIPTION
In Webonyx, the getType() function can return null. In GraphQLite, it throws an error. This makes using the SchemaPrinter impossible.
We override the SchemaPrinter to stop searching for the "Subscription" type.

Note: this can only work if https://github.com/webonyx/graphql-php/pull/1380 is merged.