### PR TITLE
The 'Validate' attribute works with a string passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /vendor
 /build
 /.phpunit.result.cache
+/.phpunit.cache
 tags

--- a/src/Annotations/Validate.php
+++ b/src/Annotations/Validate.php
@@ -6,7 +6,6 @@ namespace TheCodingMachine\GraphQLite\Laravel\Annotations;
 
 use Attribute;
 use BadMethodCallException;
-use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface;
 use function is_string;
 use function ltrim;
@@ -30,7 +29,7 @@ class Validate implements ParameterAnnotationInterface
     private $rule;
 
     /**
-     * @param array<string, mixed> $values
+     * @param array<string, mixed>|string $rule
      */
     public function __construct($rule = [])
     {
@@ -43,7 +42,7 @@ class Validate implements ParameterAnnotationInterface
                 $this->for = ltrim($values['for'], '$');
             }
         }
-        if (! isset($values['rule'])) {
+        if (! isset($this->rule)) {
             throw new BadMethodCallException('The @Validate annotation must be passed a rule. For instance: "#Validate("email")" in PHP 8+ or "@Validate(for="$email", rule="email")" in PHP 7+');
         }
     }

--- a/src/Annotations/Validate.php
+++ b/src/Annotations/Validate.php
@@ -42,7 +42,7 @@ class Validate implements ParameterAnnotationInterface
                 $this->for = ltrim($values['for'], '$');
             }
         }
-        if (! isset($this->rule)) {
+        if (empty($this->rule)) {
             throw new BadMethodCallException('The @Validate annotation must be passed a rule. For instance: "#Validate("email")" in PHP 8+ or "@Validate(for="$email", rule="email")" in PHP 7+');
         }
     }

--- a/tests/Annotations/ValidateTest.php
+++ b/tests/Annotations/ValidateTest.php
@@ -2,20 +2,9 @@
 
 namespace TheCodingMachine\GraphQLite\Laravel\Providers;
 
-
 use BadMethodCallException;
-use GraphQL\Error\DebugFlag;
-use GraphQL\Executor\ExecutionResult;
-use GraphQL\Server\StandardServer;
 use Orchestra\Testbench\TestCase;
-use TheCodingMachine\GraphQLite\Http\HttpCodeDeciderInterface;
 use TheCodingMachine\GraphQLite\Laravel\Annotations\Validate;
-use TheCodingMachine\GraphQLite\Laravel\Listeners\CachePurger;
-use TheCodingMachine\GraphQLite\Schema;
-use Illuminate\Http\Request;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use TheCodingMachine\GraphQLite\Laravel\Controllers\GraphQLiteController;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class ValidateTest extends TestCase
 {

--- a/tests/Annotations/ValidateTest.php
+++ b/tests/Annotations/ValidateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Laravel\Providers;
+
+
+use BadMethodCallException;
+use GraphQL\Error\DebugFlag;
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Server\StandardServer;
+use Orchestra\Testbench\TestCase;
+use TheCodingMachine\GraphQLite\Http\HttpCodeDeciderInterface;
+use TheCodingMachine\GraphQLite\Laravel\Annotations\Validate;
+use TheCodingMachine\GraphQLite\Laravel\Listeners\CachePurger;
+use TheCodingMachine\GraphQLite\Schema;
+use Illuminate\Http\Request;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use TheCodingMachine\GraphQLite\Laravel\Controllers\GraphQLiteController;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class ValidateTest extends TestCase
+{
+    public function testStringArgument(): void
+    {
+        $validator = new Validate('any-rule');
+        $this->assertEquals('any-rule', $validator->getRule());
+    }
+
+    public function testArrayArgument(): void
+    {
+        $validator = new Validate(['rule' => 'any-rule']);
+        $this->assertEquals('any-rule', $validator->getRule());
+    }
+
+    public function testArrayArgumentWithRuleAndForProperties(): void
+    {
+        $validator = new Validate([
+            'rule' => 'any-rule',
+            'for' => 'any-for',
+        ]);
+        $this->assertEquals('any-rule', $validator->getRule());
+        $this->assertEquals('any-for', $validator->getTarget());
+    }
+
+    public function testRuleShouldNotBeEmpty(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $validator = new Validate('');
+    }
+}

--- a/tests/Fixtures/App/Http/Controllers/TestController.php
+++ b/tests/Fixtures/App/Http/Controllers/TestController.php
@@ -55,4 +55,14 @@ class TestController
     {
         return 'success';
     }
+
+    /** @Query() */
+    public function testValidatorForParameterPHP8(
+        #[Validate("required")]
+        string $foo,
+        #[Validate("sometimes")]
+        null|string $bar,
+    ): string {
+        return 'success';
+    }
 }


### PR DESCRIPTION
Fix the `Validate` Attribute. Currently the `'rule'` argument passed to the `Validate` constructor is normalized but if the variable type is `string`, then it's not handled properly. Now the Validate attribute works properly if it's initialized with something like this:

```php
<?php

class Foo {
  public function bar(
    #[Validate('some-rule')]
    string $name
  ): string {
    return 'ok';
  }
}
```